### PR TITLE
added explicit property type declaration in mutation builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xanthous/dgraph-orm",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "dgraph ORM in TypeScript",
   "main": "dist/index.js",
   "author": "Simon Liang <simon@x-tech.io>",

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -1,3 +1,5 @@
+import { NamedNode, DataFactory } from '@xanthous/n3';
+
 import { ObjectLiteral } from '../utils/type';
 
 // TODO: dgraph type enums
@@ -12,6 +14,17 @@ export enum PropertyType {
   Geo = 'geo',
   Password = 'password',
   Uid = 'uid',
+}
+
+export enum DataType {
+  Default = 'xs:string',
+  Int = 'xs:int',
+  Float = 'xs:float',
+  String = 'xs:string',
+  Bool = 'xs:bool',
+  DateTime = 'xs:dateTime',
+  Geo = 'xs:geo',
+  Password = 'xs:string',
 }
 
 const REFLECTED_TYPE_TO_PREDICATE_TYPE: ObjectLiteral<PropertyType> = {
@@ -29,5 +42,26 @@ export namespace PropertyTypeUtils {
    */
   export function convertReflectedToPropertyType(reflected: string): PropertyType {
     return REFLECTED_TYPE_TO_PREDICATE_TYPE[reflected];
+  }
+
+  export function getLiteralTypeNamedNode(propertyType: PropertyType): NamedNode {
+    switch (propertyType) {
+      case PropertyType.Default:
+        return DataFactory.namedNode(DataType.Default);
+      case PropertyType.Int:
+        return DataFactory.namedNode(DataType.Int);
+      case PropertyType.Float:
+        return DataFactory.namedNode(DataType.Float);
+      case PropertyType.Bool:
+        return DataFactory.namedNode(DataType.Bool);
+      case PropertyType.DateTime:
+        return DataFactory.namedNode(DataType.DateTime);
+      case PropertyType.Geo:
+        return DataFactory.namedNode(DataType.Geo);
+      case PropertyType.Password:
+        return DataFactory.namedNode(DataType.Password);
+      default:
+        return DataFactory.namedNode(DataType.Default);
+    }
   }
 }

--- a/tests/treelab.spec.ts
+++ b/tests/treelab.spec.ts
@@ -21,6 +21,7 @@ test('Should work', () => {
   const cell = column.hasCell.get()[0];
 
   column.columnType = 'COLUMN_NEW_TYPE';
+  column.isDefault = true;
   cell.cellType = 'TEST_NEW_TYPE';
   column.hasCell.withFacet(new ColumnCellTestFacet('42')).update(cell);
 


### PR DESCRIPTION
Property types are added following the dGraph spec. Works with our current type inference.

![image](https://user-images.githubusercontent.com/1154575/72586246-04cb5480-392c-11ea-9927-9aca551668db.png)
