### PR TITLE
Fixed ignoring of falsey facet values by transaction builder

### DIFF
--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -261,7 +261,7 @@ export class Transaction<T extends Object, V> implements ITransaction<T> {
 
             const facetValue = facetDataMap[idx];
 
-            if (facetValue) {
+            if (facetValue !== undefined) {
               acc[f.args.propertyName] = facetValue;
             }
 


### PR DESCRIPTION
Fixed issue where falsey facet values (such as `0`) were being ignored by transaction builder. Added unit test to compliment fix.
