### PR TITLE
disable diff tracking per object

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@types/debug": "^4.1.5",
+    "@types/lodash": "^4.14.165",
     "@types/n3": "^1.1.1",
     "@xanthous/n3": "^1.3.5",
     "class-validator": "^0.10.2",

--- a/src/transaction/diff-tracker.ts
+++ b/src/transaction/diff-tracker.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import { IObjectLiteral } from '../utils/type';
 
 export class DiffTracker {
@@ -33,7 +34,7 @@ export class DiffTracker {
       enumerable: true,
       set: function(value: any) {
         tracker.ensureInstance(target, propertyName, diffKey || propertyName);
-        tracker._instances.get(target)![propertyName].set(value, target.trackChanges);
+        tracker._instances.get(target)![propertyName].set(value, get(target, 'trackChanges'));
       },
       get: function() {
         tracker.ensureInstance(target, propertyName, diffKey || propertyName);

--- a/src/transaction/diff-tracker.ts
+++ b/src/transaction/diff-tracker.ts
@@ -33,7 +33,7 @@ export class DiffTracker {
       enumerable: true,
       set: function(value: any) {
         tracker.ensureInstance(target, propertyName, diffKey || propertyName);
-        tracker._instances.get(target)![propertyName].set(value);
+        tracker._instances.get(target)![propertyName].set(value, target.trackChanges);
       },
       get: function() {
         tracker.ensureInstance(target, propertyName, diffKey || propertyName);
@@ -149,8 +149,8 @@ export class DiffValue<T> {
     this._dirty = false;
   }
 
-  set(value: T): void {
-    this._dirty = true;
+  set(value: T, trackChanges: boolean = true): void {
+    this._dirty = trackChanges;
     this._value = value;
   }
 

--- a/src/transaction/predicate-impl.ts
+++ b/src/transaction/predicate-impl.ts
@@ -44,7 +44,9 @@ export class PredicateImpl<T = any, U = any> implements IPredicate<T, U> {
     }
 
     this._data.push(node);
-    this._diff.predicates.get(this)!.add(node);
+    if (this._owner.trackChanges) {
+      this._diff.predicates.get(this)!.add(node);
+    }
 
     return this;
   }

--- a/src/transaction/predicate-impl.ts
+++ b/src/transaction/predicate-impl.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import { IPredicate } from '../index';
 import { FacetStorage } from './facet-storage';
 import { IDiffEnvelope } from './transaction';
@@ -44,7 +45,7 @@ export class PredicateImpl<T = any, U = any> implements IPredicate<T, U> {
     }
 
     this._data.push(node);
-    if (this._owner.trackChanges) {
+    if (get(this._owner, 'trackChanges', true)) {
       this._diff.predicates.get(this)!.add(node);
     }
 

--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -1,5 +1,6 @@
 import { Quad } from 'n3';
 import uniqid from 'uniqid';
+import { set } from 'lodash';
 
 import { DiffTracker } from './diff-tracker';
 import { FacetStorage } from './facet-storage';
@@ -99,7 +100,7 @@ export class Transaction<T extends Object, V> implements ITransaction<T> {
     }
 
     const nodeInstance = new nodeCls();
-    nodeInstance.trackChanges = trackChanges;
+    set(nodeInstance, 'trackChanges', trackChanges)
     this.trackProperties(nodeInstance);
     this.trackPredicatesForFreshNode(nodeInstance);
 

--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -92,13 +92,14 @@ export class Transaction<T extends Object, V> implements ITransaction<T> {
 
   public nodeFor<N extends Object>(nodeCls: Constructor<N>): N;
   public nodeFor<N extends Object, V extends Object>(nodeCls: Constructor<N>, data: V & { uid?: string }): N;
-  public nodeFor<N extends Object, V extends Object>(nodeCls: Constructor<N>, data?: V & { uid?: string }): N {
+  public nodeFor<N extends Object, V extends Object>(nodeCls: Constructor<N>, data?: V & { uid?: string }, trackChanges: boolean = true): N {
     const uids = MetadataStorage.Instance.uids.get(nodeCls.name);
     if (!uids || uids.length === 0) {
       throw new Error('Node must have a property decorated with @Uid');
     }
 
     const nodeInstance = new nodeCls();
+    nodeInstance.trackChanges = trackChanges;
     this.trackProperties(nodeInstance);
     this.trackPredicatesForFreshNode(nodeInstance);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,6 +949,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
 "@types/long@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"


### PR DESCRIPTION
providing a minimum implementation of what we need for treelab-api: the ability to enable/disable diff tracking per object. this allows us to reduce the number of mutations generated for some updates by 99%. usage would be as follows:

```
const node = ormTransaction.nodeFor(CellNode, initialData, false); // create a new object with diff tracking disabled
node.attributeX = 'bla'; // set some attributes on the object
node.trackChanges = true; // enable diff tracking beyond this point
```